### PR TITLE
Mobile sidebar close

### DIFF
--- a/components/tailored/core/sidebar/Sidebar.vue
+++ b/components/tailored/core/sidebar/Sidebar.vue
@@ -27,6 +27,10 @@ export default Vue.extend({
     ...mapState(['ui']),
   },
   mounted() {
+    /**
+     * Opens and closes the left hand sidebar upon clicking on 'direct-chat' or 'files-browse'
+     * when user is on a mobile device
+     */
     if (this.$route.name?.includes('files-browse') && this.$device.isMobile) {
       this.$props.toggle()
     }

--- a/components/tailored/core/sidebar/Sidebar.vue
+++ b/components/tailored/core/sidebar/Sidebar.vue
@@ -23,16 +23,16 @@ export default Vue.extend({
       default: () => [],
     },
   },
-  mounted() {
-      if (this.$route.name?.includes('files-browse') && this.$device.isMobile) {
-        this.$props.toggle()
-      }
-      if (this.$route.name?.includes('chat-direct') && this.$device.isMobile) {
-        this.$props.toggle()
-      }
-    },
   computed: {
     ...mapState(['ui']),
+  },
+  mounted() {
+    if (this.$route.name?.includes('files-browse') && this.$device.isMobile) {
+      this.$props.toggle()
+    }
+    if (this.$route.name?.includes('chat-direct') && this.$device.isMobile) {
+      this.$props.toggle()
+    }
   },
 })
 </script>

--- a/components/tailored/core/sidebar/Sidebar.vue
+++ b/components/tailored/core/sidebar/Sidebar.vue
@@ -23,6 +23,14 @@ export default Vue.extend({
       default: () => [],
     },
   },
+  mounted() {
+      if (this.$route.name?.includes('files-browse') && this.$device.isMobile) {
+        this.$props.toggle()
+      }
+      if (this.$route.name?.includes('chat-direct') && this.$device.isMobile) {
+        this.$props.toggle()
+      }
+    },
   computed: {
     ...mapState(['ui']),
   },


### PR DESCRIPTION
Have sidebar on mobile devices close automatically when a user goes to `chat-direct` or `files-browse`