### PR TITLE
fix(Files Page): File page to be responsive

### DIFF
--- a/components/tailored/files/file/File.html
+++ b/components/tailored/files/file/File.html
@@ -1,4 +1,4 @@
-<div class="file">
+<div :class="`${$device.isMobile ? 'file mobile-file' : 'file'}`">
   <div class="quick-actions">
     <font-awesome-icon :icon="['far', 'link']" class="share" v-if="item.meta && item.meta.shared" />
     <font-awesome-icon :icon="['far', 'heart']" class="like" v-if="item.meta && item.meta.liked" />

--- a/components/tailored/files/file/File.less
+++ b/components/tailored/files/file/File.less
@@ -1,5 +1,6 @@
 .file {
-  width: 170px;
+  width: 20%;
+  min-width: 160px;
   margin-right: @light-spacing;
   margin-bottom: @light-spacing;
   border-radius: @corner-rounding-smaller;
@@ -55,8 +56,13 @@
   }
 
 }
+
 @media only screen and (max-width: 768px) {
-  .file {
-     width: 47%;
-   }
- }
+  .mobile-file {
+    width: 47%;
+    min-width: 100px;
+    .file-icon {
+      margin-left: 10vw;
+    }
+  }
+}

--- a/components/tailored/files/file/File.less
+++ b/components/tailored/files/file/File.less
@@ -55,3 +55,8 @@
   }
 
 }
+@media only screen and (max-width: 768px) {
+  .file {
+     width: 47%;
+   }
+ }

--- a/pages/files/browse/Browse.html
+++ b/pages/files/browse/Browse.html
@@ -1,4 +1,8 @@
-<div id="files">
+<div id="files"  class="hidden-scroll" v-scroll-lock="true">
+
+  <div :class="`${$device.isMobile ? 'mobile-file-aside' : 'hidden-file-aside'}`">
+    <TailoredFilesAside />
+  </div>
   
   <div class="files-top">
     <TailoredFilesFilepath :path="path" :pull="pull" :setPath="setPath" />
@@ -31,8 +35,8 @@
         </div>
       </UiScroll>
     </div>
-    <div class="files-right">
-      <TailoredFilesAside />
+    <div :class="`${$device.isMobile ? 'hidden-file-aside' : 'files-right'}`">
+      <TailoredFilesAside v-if="!$device.isMobile"/>
     </div>
   </div>
 </div>

--- a/pages/files/browse/Browse.html
+++ b/pages/files/browse/Browse.html
@@ -1,5 +1,4 @@
 <div id="files"  class="hidden-scroll" v-scroll-lock="true">
-
   <div :class="`${$device.isMobile ? 'mobile-file-aside' : 'hidden-file-aside'}`">
     <TailoredFilesAside />
   </div>

--- a/pages/files/browse/Browse.less
+++ b/pages/files/browse/Browse.less
@@ -1,5 +1,6 @@
 #files {
   padding: @normal-spacing;
+  // min-width: 70vw;
 
   .files-container {
     display: flex;
@@ -31,6 +32,19 @@
   }
   .input {
     margin-bottom: @normal-spacing;
+  }
+
+  .mobile-file-aside{
+    padding-bottom: 10px;
+  }
+
+  .hidden-file-aside{
+    display: none;
+  }
+
+  .scroll-area {
+    // background-color: lightgoldenrodyellow;
+    max-height: 75vh;
   }
 }
 

--- a/pages/files/browse/Browse.less
+++ b/pages/files/browse/Browse.less
@@ -43,7 +43,6 @@
   }
 
   .scroll-area {
-    // background-color: lightgoldenrodyellow;
     max-height: 75vh;
   }
 }

--- a/pages/files/browse/Browse.less
+++ b/pages/files/browse/Browse.less
@@ -1,6 +1,5 @@
 #files {
   padding: @normal-spacing;
-  // min-width: 70vw;
 
   .files-container {
     display: flex;


### PR DESCRIPTION
SA-119: Make the files page responsive

fix(Files Page): Have "files" on mobile stack up to 2 in a row
fix(Files Page): Have "files-aside" to render at the top of the page on mobile, but still on the right side on the desktop.
fix(Files Page): Add scrolling for "Files Browse" when on mobile to accommodate for "files-aside" being rendered at the top.