### PR TITLE
chore(Build): Fixed scripts to build linux and windows versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "start": "nuxt start",
     "generate": "nuxt generate",
     "android-generate": "yarn generate; npx cap copy; npx cap sync;",
-    "electron-mac": "yarn generate; npx cap copy @capacitor-community/electron; npx cap sync @capacitor-community/electron; cd electron; yarn; yarn electron:build-mac",
-    "electron-windows": "yarn generate; npx cap copy @capacitor-community/electron; npx cap sync @capacitor-community/electron; cd electron; yarn; yarn electron:build-win",
-    "electron-linux": "yarn generate; npx cap copy @capacitor-community/electron; npx cap sync @capacitor-community/electron; cd electron; yarn; yarn electron:build-linux",
+    "electron-mac": "yarn generate && npx cap update @capacitor-community/electron && npx cap copy @capacitor-community/electron && npx cap sync @capacitor-community/electron && cd electron && yarn && yarn electron:build-mac",
+    "electron-windows": 
+      "yarn generate && npx cap update @capacitor-community/electron && npx cap copy @capacitor-community/electron && npx cap sync @capacitor-community/electron && cd electron && yarn && yarn electron:build-windows",
+    "electron-linux": 
+      "yarn generate && npx cap update @capacitor-community/electron && npx cap copy @capacitor-community/electron && npx cap sync @capacitor-community/electron && cd electron && yarn && yarn electron:build-linux"
+    ,
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
     "lint": "yarn lint:js",
     "test": "jest"


### PR DESCRIPTION
The added update command is needed to build a file in the capacitor-community electron node module folder that actual build needs later.