### PR TITLE
fix(sidebar): Fix 'Red "New Message" Bar extends past Sidemenu while viewing in a smaller window'

### DIFF
--- a/components/tailored/core/sidebar/Sidebar.less
+++ b/components/tailored/core/sidebar/Sidebar.less
@@ -134,11 +134,6 @@
     z-index: 3;
     .sidebar-inner {
       max-height: calc(100vh - @mobile-sidebar-inner-offset);
-      .users {
-        .inline-notification {
-          width: 100vw - 30rem;
-        }
-      }
     }
     .sidebar-inner-streaming {
       max-height: calc(100vh - @sidebar-inner-offset - @mobile-sidebar-inner-streaming-pad);


### PR DESCRIPTION
Fix 'Red "New Message" Bar extends past Sidemenu while viewing in a smaller window'