### PR TITLE
fix(iOS): 

### DIFF
--- a/utilities/Notifications.ts
+++ b/utilities/Notifications.ts
@@ -22,6 +22,10 @@ import { LocalNotifications } from '@capacitor/local-notifications'
 //     minute?: number
 //   }
 // }
+const isSupported = (): boolean =>
+  'Notification' in window &&
+  'serviceWorker' in navigator &&
+  'PushManager' in window
 
 export const Notifications = class Notifications {
   currentPlatform: string = 'android' // 'ios', 'android', 'web'
@@ -32,7 +36,7 @@ export const Notifications = class Notifications {
     this.currentPlatform = Capacitor.getPlatform() // ios, web, android
     if (this.currentPlatform === 'web') {
       // all mount needs for web/pwa
-      if (this.notificationPermission !== 'granted') {
+      if (this.notificationPermission !== 'granted' && isSupported()) {
         Notification.requestPermission().then((result: any) => {
           this.notificationPermission = result
         })
@@ -99,7 +103,10 @@ export const Notifications = class Notifications {
    */
   requestNotificationPermission(): any {
     // @ts-ignore
-    if (this.currentPlatform === 'web' || this.currentPlatform === 'electron') {
+    if (
+      (this.currentPlatform === 'web' || this.currentPlatform === 'electron') &&
+      isSupported()
+    ) {
       Notification.requestPermission()
     }
     if (this.currentPlatform === 'android') {


### PR DESCRIPTION
IOS web rendering engine does not support the Notification api that every other browser supports, now we check to see if the browser is compatible and disables the notification object if not supported.