### PR TITLE
Fix(Network Settings): Fix 'Allow Embeds toggle not works'

### DIFF
--- a/components/tailored/settings/pages/network/index.vue
+++ b/components/tailored/settings/pages/network/index.vue
@@ -20,7 +20,7 @@ export default Vue.extend({
     },
     isAllowEmbeddedLinks: {
       set(state) {
-        this.$store.commit('embeddedLinks', state)
+        this.$store.commit('settings/embeddedLinks', state)
       },
       get() {
         return this.settings.embeddedLinks


### PR DESCRIPTION
Allow Embeds button located in Network tab in Settings is unresponsive