### PR TITLE
fix(chat bar): Fix placeholder overlapping issue on chat bar

### DIFF
--- a/components/tailored/core/chatbar/Chatbar.html
+++ b/components/tailored/core/chatbar/Chatbar.html
@@ -17,10 +17,10 @@
     <div contenteditable="true" autocapitalize="off"
       :class="`messageuser hidden-scroll ${hasCommand ? 'has-command' : ''}`"
       ref="messageuser"
+      :placeholder="$t('global.talk')"
       @keydown="handleInputKeydown"
       @keyup="handleInputKeyup"
       @drop="handleDrop"></div>
-    <span class="placeholder">{{ placeholder }}</span>
     <div
       :data-tooltip="$t('wallet.send_money')"
       v-on:click="toggleEnhancers"

--- a/components/tailored/core/chatbar/Chatbar.less
+++ b/components/tailored/core/chatbar/Chatbar.less
@@ -1,14 +1,6 @@
 #chatbar {
   margin-top: @light-spacing;
   width: 100%;
-  .placeholder {
-    position: absolute;
-    left: 4.5rem;
-    opacity: 1;
-    font-size: @text-size;
-    pointer-events: none;
-    padding: 0.25rem @light-spacing;
-  }
   &.has-reply {
     margin-top: 0;
   }
@@ -107,8 +99,11 @@
       resize: none;
       font-size: @text-size;
       padding-top: 6px;
+      &[placeholder]:empty:before {
+        content: attr(placeholder);
+      }
     }
-
+    
     .control-icon {
       justify-self: center;
       align-self: center;


### PR DESCRIPTION
https://satellite-im.atlassian.net/jira/software/projects/SA/boards/3?selectedIssue=SA-306
"Speak Freely" in the text box for chat does not disappear when pasting a link.
Convert placeholder from individual span to natural placeholder.