### PR TITLE
fix(Chat bar): Prevent empty message from being sent when clicking the send button

### DIFF
--- a/components/tailored/core/chatbar/Chatbar.vue
+++ b/components/tailored/core/chatbar/Chatbar.vue
@@ -355,7 +355,7 @@ export default Vue.extend({
      * @example v-on:click="sendMessage"
      */
     sendMessage() {
-      if(!this.value) return
+      if (!this.value) return
       this.$store.dispatch('ui/sendMessage', {
         value: this.value,
         user: this.$mock.user,

--- a/components/tailored/core/chatbar/Chatbar.vue
+++ b/components/tailored/core/chatbar/Chatbar.vue
@@ -355,6 +355,7 @@ export default Vue.extend({
      * @example v-on:click="sendMessage"
      */
     sendMessage() {
+      if(!this.value) return
       this.$store.dispatch('ui/sendMessage', {
         value: this.value,
         user: this.$mock.user,


### PR DESCRIPTION
Prevent empty message from being sent when clicking the send button