### PR TITLE
fix(Chat): Fix 'After editing a message in chat, the message will be missing the last character'

### DIFF
--- a/components/tailored/messaging/message/edit/Edit.vue
+++ b/components/tailored/messaging/message/edit/Edit.vue
@@ -115,9 +115,6 @@ export default Vue.extend({
           this.cancelMessage()
           break
       }
-      this.$nextTick(() => {
-        this.handleInputChange()
-      })
     },
     handleInputKeyup(event: KeyboardEvent) {
       const messageBox = this.$refs.messageBox as HTMLElement
@@ -129,6 +126,9 @@ export default Vue.extend({
           }
           break
       }
+      this.$nextTick(() => {
+        this.handleInputChange()
+      })
     },
   },
 })


### PR DESCRIPTION
Fix 'After editing a message in chat, the message will be missing the last character'