### PR TITLE
Add PR template into project

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--  Thanks for sending a pull request!
+If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Satellite-Absolute/wiki/Contributing
+-->
+
+**What this PR does** 📖
+
+**Which issue(s) this PR fixes** 🔨
+
+Fixes #
+
+**Special notes for reviewers** 🗒️
+
+**Additional comments** 🎤


### PR DESCRIPTION
Summary

- Add PR template into project

<img width="448" alt="Screenshot 2021-11-15 at 00 29 28" src="https://user-images.githubusercontent.com/29093946/141705340-9a9c98f1-3501-4a8a-b525-f3011758ef4c.png">


This can be helpful to add more information on the PR description when opening the PR. 


cc @WanderingHogan let me know your thoughts on it! we can also remove/add any information from the PR template.


