### PR TITLE
Fix typo on /auth/unlock

### DIFF
--- a/pages/auth/unlock/Unlock.html
+++ b/pages/auth/unlock/Unlock.html
@@ -4,7 +4,7 @@
       <info-icon size="0.8x" />
       <TypographySubtitle :size="6" :text="$t('pages.unlock.create')" />
       <TypographyText text="Create a pin to protect your account." />
-      <TypographyText text="The pin can be anything you want, just don't foreget it." />
+      <TypographyText text="The pin can be anything you want, just don't forget it." />
     </div>
     <InteractablesInputGroup
       v-model="pin"


### PR DESCRIPTION
Before

<img width="745" alt="Screenshot 2021-11-15 at 15 02 49" src="https://user-images.githubusercontent.com/29093946/141804324-b1b7c947-8f77-44cf-9667-1fe14840be06.png">

After

<img width="643" alt="Screenshot 2021-11-15 at 15 03 13" src="https://user-images.githubusercontent.com/29093946/141804395-3b97ef32-1f56-4509-9de7-c6f5d98a2c43.png">


