### PR TITLE
Fix typo on /auth/register

### DIFF
--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -309,7 +309,7 @@ export default {
       create: 'Registration',
       sign_in: 'Sign in',
       photo_text:
-        'Customize how the world sees you, chose something memerable.',
+        'Customize how the world sees you, choose something memorable.',
       username: 'Username',
       username_placeholder: 'Neil Spaceman...',
       status: 'Status',


### PR DESCRIPTION
Before

<img width="881" alt="Screenshot 2021-11-15 at 15 06 47" src="https://user-images.githubusercontent.com/29093946/141804941-7e9e163c-dde9-435c-9f70-55f4549905a5.png">

After

<img width="832" alt="Screenshot 2021-11-15 at 15 06 23" src="https://user-images.githubusercontent.com/29093946/141804877-bb7aa69a-e0bb-4cbc-8716-731bb384ef0f.png">
