### PR TITLE
Fix typo on personalize section

### DIFF
--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -193,7 +193,7 @@ export default {
       },
       personalize: {
         title: 'Personalize Satellite',
-        subtitle: 'Make it your own and chose cusotm colors & themes.',
+        subtitle: 'Make it your own and choose custom colors & themes.',
         theme: 'Color Theme',
         language: 'Language',
       },


### PR DESCRIPTION
Fix typo on personalize section

Before

<img width="600" alt="Screenshot 2021-11-15 at 15 18 33" src="https://user-images.githubusercontent.com/29093946/141806835-4e506b06-108d-47ce-b2cb-24f63aa26c9b.png">

After

<img width="695" alt="Screenshot 2021-11-15 at 15 19 07" src="https://user-images.githubusercontent.com/29093946/141806928-5689428c-a291-4afa-984b-2d842e513ef0.png">

