### PR TITLE
Fix notifications typo

### DIFF
--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -92,7 +92,7 @@ export default {
       notifications: {
         title: 'Notifications Settings',
         notes:
-          'Notifications work different on every platform. On Web, you need to request noticications. On Desktop and Android notications are enabled by default.',
+          'Notifications work different on every platform. On Web, you need to request notifications. On Desktop and Android notications are enabled by default.',
         enabled: 'Enable or Disable Notifications',
         labels: {
           current_platform: 'Your current platform is:',

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -92,7 +92,7 @@ export default {
       notifications: {
         title: 'Notifications Settings',
         notes:
-          'Notifications work different on every platform. On Web, you need to request notifications. On Desktop and Android notications are enabled by default.',
+          'Notifications work different on every platform. On Web, you need to request notifications. On Desktop and Android notifications are enabled by default.',
         enabled: 'Enable or Disable Notifications',
         labels: {
           current_platform: 'Your current platform is:',


### PR DESCRIPTION
Fix notifications typo

Before
<img width="1557" alt="Screenshot 2021-11-15 at 17 24 59" src="https://user-images.githubusercontent.com/29093946/141826468-759e3968-ed4b-4e5b-944c-7fcf7ee1353b.png">

After
<img width="1497" alt="Screenshot 2021-11-15 at 17 25 26" src="https://user-images.githubusercontent.com/29093946/141826544-01a3a101-3ca7-47ca-8029-02276b03aee6.png">

