### PR TITLE
fix(Chat): Add friends component to new chat modal

### DIFF
--- a/components/tailored/friends/quick/Quick.html
+++ b/components/tailored/friends/quick/Quick.html
@@ -1,14 +1,22 @@
 <div id="quick-chat" v-if="$store.state.ui.modals.quickchat">
   <TypographySubtitle :size="6" text="New Chat" />
-  <TypographyText text="Select one or more of your friends to chat in groups, or one-on-one." />
-  <InteractablesInput 
-    type="primary"
+  <TypographyText
+    text="Select one or more of your friends to chat in groups, or one-on-one."
+  />
+  <TailoredSettingsPagesUserSearch
+    v-model="friends"
+    :placeholder="$t('servers.create.select_friends_placeholder')"
     size="small"
-    class="search"
-    placeholder="Search" />
-  <div class="scroll-container">
-    <UiScroll verticalScroll scrollbarVisibility="scroll" enableWrap>
-      <UiUser v-for="user in $mock.users" :user="user" :key="user.publicKey" />
-    </UiScroll>
+    type="primary"
+    drop="top"
+  />
+  <div v-if="friends.length" class="submit-container">
+    <InteractablesButton
+      type="primary"
+      size="small"
+      :text="$t('pages.chat.chat_now')"
+      class="create-server-btn"
+      :action="confirm"
+    />
   </div>
 </div>

--- a/components/tailored/friends/quick/Quick.less
+++ b/components/tailored/friends/quick/Quick.less
@@ -6,13 +6,12 @@
   position: fixed;
   width: 18rem;
   top: 11rem;
-  padding: @light-spacing @light-spacing;
+  padding: @light-spacing @light-spacing @normal-spacing @light-spacing;
   left: @sidebar-size + 2rem;
   z-index: @base-z-index + 10;
   display: flex;
   flex-direction: column;
   max-height: 24rem;
-  overflow-y: hidden;
 
   .subtitle {
     margin: 0;
@@ -20,13 +19,14 @@
     font-size: @text-size;
   }
 
-  .search {
+  .search, .user-search {
     margin-top: @normal-spacing;
   }
 
-  .scroll-container {
-    flex: 1;
-    margin-top: @light-spacing;
-    height: 0;
+  .submit-container {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1em;
+    width: 100%;
   }
 }

--- a/components/tailored/friends/quick/Quick.vue
+++ b/components/tailored/friends/quick/Quick.vue
@@ -9,9 +9,9 @@ export default Vue.extend({
       friends: [],
     }
   },
-  watch: {
-    friends(newFriends) {
-      console.log(newFriends)
+  methods: {
+    confirm() {
+      /* Create Group and Start Chat.  For now Group Messages needs some changes on Solana & IPFS so leave this blank  */
     },
   },
 })

--- a/components/tailored/friends/quick/Quick.vue
+++ b/components/tailored/friends/quick/Quick.vue
@@ -4,6 +4,16 @@
 import Vue from 'vue'
 export default Vue.extend({
   name: 'Quick',
+  data() {
+    return {
+      friends: [],
+    }
+  },
+  watch: {
+    friends(newFriends) {
+      console.log(newFriends)
+    },
+  },
 })
 </script>
 

--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -260,6 +260,7 @@ export default {
     chat: {
       new_message: 'messages',
       jump_to_current: 'View New Messages',
+      chat_now: 'chat now',
     },
   },
   servers: {


### PR DESCRIPTION
**What this PR does** 📖
Add friends component to new chat modal
**Which issue(s) this PR fixes** 🔨
SA-370
Fixes #
- Get rid of standard inputs & Add friends components
**Special notes for reviewers** 🗒️
- @RetroPronghorn  I think we don't need copy logic from Create server modal.
  I already copied logic but decided to remove all because we can share TailoredSettingsPagesUserSearch component on Create Server Modal & New Chat Modal.  If we need some fixes or tweak, we can update TailoredSettingsPagesUserSearch  component.
- For now, group messages are not implemented (Manuel said we have to find a way to share a secret key between all the participants)... so in this case, We need to wait until they solve that..  We can just create group chat by modifying mock up data but that has no meaning. 

