### PR TITLE
fix(chatbar): control buttons become grey when user cant interact

### DIFF
--- a/assets/styles/base.less
+++ b/assets/styles/base.less
@@ -587,6 +587,9 @@ button {
     .send-message-btn {
       &:extend(.font-flair);
     }
+    [disabled] {
+      color: grey;
+    }
   }
 
   .chat-label {
@@ -700,15 +703,6 @@ button {
 }
 
 // ------------- Ui Elements-------------
-
-// Chatbar
-#chatbar {
-  .chatbar-controls {
-    .send-message-btn {
-      &:extend(.color-flair);
-    }
-  }
-}
 
 .is-chatbar-reply {
   &:extend(.background-flair);

--- a/components/views/chat/chatbar/Chatbar.html
+++ b/components/views/chat/chatbar/Chatbar.html
@@ -32,7 +32,7 @@
     <ChatbarControls
       id="chatbar-controls"
       :sendMessage="sendMessage"
-      :disabled="!recipient"
+      :disabled="!recipient || charlimit"
     />
   </div>
   <ChatbarFooter :text="text" :charlimit="charlimit" />


### PR DESCRIPTION
…erract

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Turns control buttons grey when they aren't interactable

**Which issue(s) this PR fixes** 🔨
AP-1920
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
